### PR TITLE
Add support for Llama2, Palm, Cohere, Anthropic, Replicate, Azure Models - using litellm

### DIFF
--- a/offline_tools/generator_questions/question_generator.py
+++ b/offline_tools/generator_questions/question_generator.py
@@ -9,7 +9,7 @@ from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain.schema import SystemMessage
 from langchain.output_parsers import StructuredOutputParser, ResponseSchema
 from langchain.prompts import ChatPromptTemplate, HumanMessagePromptTemplate
-from langchain.chat_models import ChatOpenAI
+from langchain.chat_models import ChatOpenAI, ChatLiteLLM
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
@@ -22,7 +22,7 @@ class QuestionGenerator:
     openai_api_key: Optional[str] = QUESTIONGENERATOR_CONFIG.get('openai_api_key', os.getenv('OPENAI_API_KEY'))
     max_tokens: Optional[int] = QUESTIONGENERATOR_CONFIG.get('max_tokens', None)
 
-    chat: BaseChatModel = ChatOpenAI(temperature=temperature, openai_api_key=openai_api_key)
+    chat: BaseChatModel = ChatLiteLLM(temperature=temperature, openai_api_key=openai_api_key)
 
     def generate_qa(self, doc: str, project: str, chunk_size: int = 300):
         no_answer_str = 'NO ANSWER'

--- a/src_langchain/llm/README.md
+++ b/src_langchain/llm/README.md
@@ -6,7 +6,9 @@ LLM is the key component to ensure the functionality of chatbot. Besides providi
 
 The chatbot uses `ChatLLM` module to generate responses as the final answer, which will be returned to the user end. In order to adapt the LangChain agent, this must be a LangChain `BaseChatModel`.
 
-By default, it uses `ChatOpenAI` from LangChain, which calls the chat service of OpenAI.
+By default, it uses `ChatLiteLLM` from LangChain, which calls the chat service of OpenAI (and Can support 50+ LLMs including Anthropic, Cohere, Google Palm, Replicate, Llama2 )
+See ChatLiteLLM usage https://python.langchain.com/docs/integrations/chat/litellm
+
 Refer to [LangChain Models](https://python.langchain.com/en/latest/modules/models.html) for more LLM options.
 
 ### Configuration

--- a/src_langchain/llm/openai_chat.py
+++ b/src_langchain/llm/openai_chat.py
@@ -2,7 +2,7 @@ import os
 import sys
 from typing import Optional
 
-from langchain.chat_models import ChatOpenAI
+from langchain.chat_models import ChatOpenAI, ChatLiteLLM
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '../..'))
 
@@ -12,7 +12,7 @@ CHAT_CONFIG = CHAT_CONFIG['openai']
 llm_kwargs = CHAT_CONFIG.get('llm_kwargs', {})
 
 
-class ChatLLM(ChatOpenAI):
+class ChatLLM(ChatLiteLLM):
     '''Chat with LLM given context. Must be a LangChain BaseLanguageModel to adapt agent.'''
     model_name: str = CHAT_CONFIG.get('openai_model', 'gpt-3.5-turbo')
     openai_api_key: Optional[str] = CHAT_CONFIG.get('openai_api_key', None)


### PR DESCRIPTION
liteLLM adds support for 50+ models with a standard I/O interface: https://github.com/BerriAI/litellm/

`ChatLiteLLM()` is integrated into langchain and allows you to call all models using the ChatOpenAI I/O interface 
https://python.langchain.com/docs/integrations/chat/litellm

Here's an example of how to use ChatLiteLLM()
```python
ChatLiteLLM(model="gpt-3.5-turbo")
ChatLiteLLM(model="claude-2", temperature=0.3)
ChatLiteLLM(model="command-nightly")
ChatLiteLLM(model="replicate/llama-2-70b-chat:2c1608e18606fad2812020dc541930f2d0495ce32eee50074220b87300bc16e1")

```